### PR TITLE
Check capistrano version to select proper argument

### DIFF
--- a/cap
+++ b/cap
@@ -11,8 +11,16 @@ _cap()
         return
     fi
 
+    local cap_opt_all
+    cap --version | grep 'Capistrano v2.' > /dev/null
+    if [ $? -eq 0 ]; then
+      cap_opt_all='-v' # Capistrano 2.x
+    else
+      cap_opt_all='-A' # Capistrano 3.x
+    fi
+
     local opts
-    opts=`cap -T -A | awk 'BEGIN {x=1}; $x>1 { if($1=="cap") { print $2}}'`
+    opts=`cap -T ${cap_opt_all} | awk 'BEGIN {x=1}; $x>1 { if($1=="cap") { print $2}}'`
     optscolon=${cur%"${cur##*:}"}
 
     COMPREPLY=( $(compgen -W "${opts}"  -- ${cur}))


### PR DESCRIPTION
The Capistrano version should be checked to support both Capistrano 2.x and Capistrano 3.x
